### PR TITLE
Fix: banner 캐로셀 css 풀리는 에러 수정

### DIFF
--- a/src/components/sliders/banner.css
+++ b/src/components/sliders/banner.css
@@ -1,40 +1,39 @@
-.slick-dots{
-    display: flex;
-    justify-content: start;
-    align-items: center;
+.slider-container .slick-dots {
+  display: flex;
+  justify-content: start;
+  align-items: center;
 }
 
-.slick-dots li{
-    padding: 0px;
-    margin: 0px 1px;
+.slider-container .slick-dots li {
+  padding: 0px;
+  margin: 0px 1px;
 }
 
-.slick-dots li button{
+.slider-container .slick-dots li button {
   height: 7.3px;
-  text-align: center; 
+  text-align: center;
 }
 
+.slider-container .slick-dots li button::before {
+  width: 20.67px;
+  height: 7.3px;
+  line-height: 0;
+  text-align: center;
+  font-size: 7.4px;
+  color: #dbdbdb;
+  opacity: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
 
-  .slick-dots li button::before {
-    width: 20.67px; 
-    height: 7.3px;
-    line-height: 0;
-    text-align: center; 
-    font-size: 7.4px;
-    color: #dbdbdb;
-    opacity: 1;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
+.slider-container .slick-dots .slick-active button::before {
+  color: #5fba8e !important;
+  background-color: #5fba8e;
+  opacity: 1;
+  border-radius: 8px !important;
+}
 
-  
-  .slick-dots .slick-active button::before {
-    color: #5fba8e !important; 
-    background-color: #5fba8e; 
-    opacity: 1;
-    border-radius: 8px !important; 
-  }
   
 
 


### PR DESCRIPTION
## Describe changes

banner 캐로셀에서 하단 dot의 css가 풀리는 에러를 수정했습니다.

## Issue number or link

- close #62

## Types of changes

What is the type of code change?
_Put an `x` in the boxes that apply_

- [x] Bugfix (changes that resolve errors)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (big changes that affect existing functionality)
- [ ] Documentation Update

## Further comments
<img width="355" alt="스크린샷 2024-12-16 오후 4 51 12" src="https://github.com/user-attachments/assets/ccd40bb5-b413-42fe-ab45-940d4737825e" />


_Please let me know if there's anything else to explain_
